### PR TITLE
Fix warning: variable $KCODE is no longer effective on ruby 1.9

### DIFF
--- a/lib/yamlator.rb
+++ b/lib/yamlator.rb
@@ -2,7 +2,7 @@
 # Helps you update Rails i18n YAML files programmatically, to be used e.g. for
 # editor extraction tools.
 
-$KCODE = 'u'
+$KCODE = 'u' if RUBY_VERSION < '1.9.0'
 
 require "yaml"
 require File.join(File.dirname(__FILE__), "ya2yaml")  # Dumps with unescaped UTF-8.


### PR DESCRIPTION
Currently I have an error when launching vim /home/subosito/.vim/bundle/vim-yaml-flattener/lib/yamlator.rb:5: warning: variable $KCODE is no longer effective; ignored. This commit fix it.
